### PR TITLE
Do not fail when user hits ctrl-c while in pager

### DIFF
--- a/eg/util.py
+++ b/eg/util.py
@@ -141,11 +141,14 @@ def page_string(str_to_page, pager_cmd):
     elif pager_cmd == FLAG_FALLBACK:
         use_fallback_page_function = True
 
-    if use_fallback_page_function:
-        pydoc.pager(str_to_page)
-    else:
-        # Otherwise, obey the user.
-        pydoc.pipepager(str_to_page, cmd=pager_cmd)
+    try:
+        if use_fallback_page_function:
+            pydoc.pager(str_to_page)
+        else:
+            # Otherwise, obey the user.
+            pydoc.pipepager(str_to_page, cmd=pager_cmd)
+    except KeyboardInterrupt:
+        pass
 
 
 def _get_contents_of_file(path):

--- a/test/util_test.py
+++ b/test/util_test.py
@@ -795,6 +795,30 @@ def _helper_assert_file_contents(
         assert_equal(actual, target_contents)
 
 
+@patch('eg.util.pydoc.pipepager', side_effect=KeyboardInterrupt)
+def test_page_string_excepts_keyboard_interrupt_if_not_less(pipepager_mock):
+    """
+    Do not fail when user hits ctrl-c while in pager.
+    """
+    try:
+        util.page_string('page me plz', 'cat')
+    except KeyboardInterrupt:
+        raise AssertionError('Should not have got this far')
+    pipepager_mock.assert_called_once_with('page me plz', cmd='cat')
+
+
+@patch('eg.util.pydoc.pager', side_effect=KeyboardInterrupt)
+def test_page_string_excepts_keyboard_interrupt_if_none(pager_mock):
+    """
+    Do not fail when user hits ctrl-c while in pipepager.
+    """
+    try:
+        util.page_string('page me plz', None)
+    except KeyboardInterrupt:
+        raise AssertionError('Should not have got this far')
+    pager_mock.assert_called_once_with('page me plz')
+
+
 def test_get_contents_from_files_only_default():
     """
     Retrieve the correct file contents when only a default file is present.


### PR DESCRIPTION
As `eg` now tells `less` to quit when a keyboard interrupt (ctrl-C) is triggered by the user, it needs to handle such exception.