### PR TITLE
Additional examples for rsync

### DIFF
--- a/eg/examples/rsync.md
+++ b/eg/examples/rsync.md
@@ -16,6 +16,16 @@ copy source_dir into destination_dir converting symlinks to real files
     rsync -avL source_dir destination_dir
 
 
+copy multiple sources into destination_dir
+
+    rsync -av source1 source2 source3 destination_dir
+
+
+copy multiple sources from a specific folder into destination_dir
+
+    rsync -av source_dir/{source1,source2,source3} destination_dir
+
+
 move the contents of source_dir into destination_dir
 
     rsync -av --remove-source-files source_dir/ destination_dir

--- a/eg/examples/rsync.md
+++ b/eg/examples/rsync.md
@@ -11,6 +11,11 @@ copy the contents of source_dir (trailing slash) into destination_dir
     rsync -av source_dir/ destination_dir
 
 
+copy source_dir into destination_dir converting symlinks to real files
+
+    rsync -avL source_dir destination_dir
+
+
 move the contents of source_dir into destination_dir
 
     rsync -av --remove-source-files source_dir/ destination_dir


### PR DESCRIPTION
Here are a few rsync examples that I find useful to know.

The "multiple sources from a specific folder" example uses brace-expansion. I did some research regarding the portability of this and while it is not POSIX-standard the basic form I use is very well supported on unix environments.  (Confirmed on my machine with bash/sh/zsh/ksh/tcsh) Here's a reference:
https://en.wikipedia.org/wiki/Comparison_of_command_shells#String_processing_and_filename_matching

I did run "nosetests" and verify the command line output for good measure.