### PR TITLE
Change from minor- to major/minor- aware version check

### DIFF
--- a/eg/color.py
+++ b/eg/color.py
@@ -86,7 +86,7 @@ class EgColorizer():
 
     def _color_helper(self, text, pattern, repl):
         # < 2.7 didn't have the flags named argument.
-        if sys.version_info[1] < 7:
+        if sys.version_info < (2, 7):
             compiled_pattern = re.compile(pattern, re.MULTILINE)
             return re.sub(
                 compiled_pattern,


### PR DESCRIPTION
Closes #75 

As noted on #75, the version checking we were doing for compatibility below 2.7 was only checking the minor version, which will lead to a regression as 3.7 becomes the default. This correctly checks for <2.7 rather than simply <x.7.