### PR TITLE
Added support for XDG_CONFIG_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ eg --examples-dir='the/default/dir' --custom-dir='my/fancy/dir' find
 ```
 
 Instead of doing this every time, you can define a configuration file. By
-default it is expected to live in `~/.egrc`. It must begin with a section
+default it is expected to live in `$XDG_CONFIG_HOME/eg.conf` 
+(usually `~/.config/eg.conf`) or `~/.egrc`. It must begin with a section
 called `eg-config` and can contain two keys: `custom-dir` and `examples-dir`.
 Here is an example of a valid config file:
 

--- a/eg/config.py
+++ b/eg/config.py
@@ -48,6 +48,16 @@ PAGER_CMD = 'pager-cmd'
 SQUEEZE = 'squeeze'
 EDITOR_CMD = 'editor-cmd'
 
+# Config location based on XDG speciification
+if 'XDG_CONFIG_HOME' in os.environ:
+    configdir = os.environ['XDG_CONFIG_HOME']
+else:
+    configdir = os.path.join('~', '.config')
+XDG_CONFIG_EGCONF_PATH = os.path.join(configdir, 'eg.conf')
+# if config file not exist at XDG_CONFIG_EGRC_PATH then reassign None
+if ~os.path.isfile(XDG_CONFIG_EGCONF_PATH):
+    XDG_CONFIG_EGCONF_PATH = None
+
 # A basic struct containing configuration values.
 #    examples_dir: path to the directory of examples that ship with eg
 #    custom_dir: path to the directory where custom examples are found
@@ -159,7 +169,7 @@ def get_egrc_config(cli_egrc_path):
     cli_egrc_path: the path to the egrc as given on the command line via
         --config-file
     """
-    resolved_path = get_priority(cli_egrc_path, DEFAULT_EGRC_PATH, None)
+    resolved_path = get_priority(cli_egrc_path, XDG_CONFIG_EGCONF_PATH, DEFAULT_EGRC_PATH)
     expanded_path = get_expanded_path(resolved_path)
 
     # Start as if nothing was defined in the egrc.


### PR DESCRIPTION
eg now search for eg.conf in XDG_CONFIG_HOME before using ~/.egrc.
The priority order is cli_config_file, eg.conf in XDG_CONFIG_HOME and then ~/.egrc.

Solves #77 