### PR TITLE
Add Command Line Interface Pages project support

### DIFF
--- a/eg/examples/clip-view.md
+++ b/eg/examples/clip-view.md
@@ -1,7 +1,5 @@
 # clip-view
 
-# Basic usage
-
 render a specific local page
 
     clip-view cat
@@ -11,8 +9,6 @@ render a specific local page
 
     clip-view path/to/cat.clip
 
-
-# Advanced usage
 
 render a page by a specific render
 

--- a/eg/examples/clip-view.md
+++ b/eg/examples/clip-view.md
@@ -1,28 +1,46 @@
 # clip-view
 
-render specific local pages
+# Basic usage
 
-    clip-view path/to/page1.clip path/to/page2.clip ...
+render a specific local page
 
-render specific remote pages
+    clip-view cat
 
-    clip-view page_name1 page_name2 ...
+render a specific local page
 
-render pages by a specific render
+    clip-view path/to/cat.clip
 
-    clip-view --render tldr|tldr-colorful|docopt|docopt-colorful page_name1 page_name2 ...
+# Advanced usage
 
-render pages with a specific color theme
+render a page by a specific render
 
-    clip-view --theme path/to/local_theme.yaml|remote_theme_name page_name1 page_name2 ...
+    clip-view --render tldr cat
 
-clear a page or theme cache
 
-    clip-view --clear-page|--clear-theme-cache
+render a page with a specific color theme
+
+    clip-view --theme awesome cat
+
+
+render a page in a specific platform
+
+    clip-view --operating-system windows dir
+
+
+clear a page cache
+
+    clip-view --clear-page-cache
+
+
+clear a theme cache
+
+    clip-view --clear-theme-cache
+
 
 display help
 
     clip-view --help
+
 
 display version
 

--- a/eg/examples/clip-view.md
+++ b/eg/examples/clip-view.md
@@ -6,9 +6,11 @@ render a specific local page
 
     clip-view cat
 
+
 render a specific local page
 
     clip-view path/to/cat.clip
+
 
 # Advanced usage
 

--- a/eg/examples/clip-view.md
+++ b/eg/examples/clip-view.md
@@ -1,0 +1,29 @@
+# clip-view
+
+render specific local pages
+
+    clip-view path/to/page1.clip path/to/page2.clip ...
+
+render specific remote pages
+
+    clip-view page_name1 page_name2 ...
+
+render pages by a specific render
+
+    clip-view --render tldr|tldr-colorful|docopt|docopt-colorful page_name1 page_name2 ...
+
+render pages with a specific color theme
+
+    clip-view --theme path/to/local_theme.yaml|remote_theme_name page_name1 page_name2 ...
+
+clear a page or theme cache
+
+    clip-view --clear-page|--clear-theme-cache
+
+display help
+
+    clip-view --help
+
+display version
+
+    clip-view --version


### PR DESCRIPTION
[Main project page](https://github.com/command-line-interface-pages)

[Here](https://github.com/command-line-interface-pages/syntax/blob/main/base.md) is the current syntax description and a [repo](https://github.com/command-line-interface-pages/cli-pages) with pages.

Render is available [here](https://github.com/command-line-interface-pages/v2-tooling/tree/main/clip-view).

![image](https://user-images.githubusercontent.com/42812113/222955158-bc4fa57a-670a-4a7c-959f-859418031881.png)

Pages for other CLIP project tools will be added later. Accepting this PR will help my project gain more popularity, thanks for understanding.

## Important

This project goal is to replace [TlDr](https://github.com/tldr-pages/tldr) project completely. CLIP project already has better client in terms of feature amount compared to [TlDr official one](https://github.com/tldr-pages/tldr-python-client) and third party clients. To be specific: it [provides](https://github.com/command-line-interface-pages/syntax/blob/main/syntax.md) more expressive and clear syntax for writing pages, [color theme](https://github.com/command-line-interface-pages/prototypes/pull/22) support. Even TlDr maintainers help me to develop it I think their main goal is to make TlDr project better and not mine, so I expect the most of the help from non-TlDr contributors.