### PR TITLE
Add prqlc examples

### DIFF
--- a/eg/examples/prqlc.md
+++ b/eg/examples/prqlc.md
@@ -1,25 +1,27 @@
 # prqlc
 
-Run the compiler interactively:
+run the compiler interactively
 
     prqlc compile
 
 
-Compile a .prql file standard output:
+compile a .prql file standard output
  
     prqlc compile file.prql
 
 
-Compile a .prql file to a .sql file:
+compile a .prql file to a .sql file
 
     prqlc compile source.prql target.sql
 
 
-Compile a query:
+compile a query
 
     echo "from employees | filter has_dog | select salary" | prqlc compile
 
 
-Watch a directory and compile on file modification:
+watch a directory and compile on file modification
 
     prqlc watch path/to/directory
+
+

--- a/eg/examples/prqlc.md
+++ b/eg/examples/prqlc.md
@@ -1,0 +1,25 @@
+# prqlc
+
+Run the compiler interactively:
+
+    prqlc compile
+
+
+Compile a .prql file standard output:
+ 
+    prqlc compile file.prql
+
+
+Compile a .prql file to a .sql file:
+
+    prqlc compile source.prql target.sql
+
+
+Compile a query:
+
+    echo "from employees | filter has_dog | select salary" | prqlc compile
+
+
+Watch a directory and compile on file modification:
+
+    prqlc watch path/to/directory


### PR DESCRIPTION
`prqlc` is a compiler for PRQL. See https://prql-lang.org/

PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.

Closes PRQL/prql/issues/2035