### PR TITLE
Fix to support Python 3.12 and above with user configuration file

### DIFF
--- a/eg/config.py
+++ b/eg/config.py
@@ -317,7 +317,11 @@ def get_config_tuple_from_egrc(egrc_path):
             config = ConfigParser.RawConfigParser()
         except AttributeError:
             config = ConfigParser()
-        config.readfp(egrc)
+        # Support Python 3.12 and above.
+        try:
+            config.readfp(egrc)
+        except:
+            config.read_file(egrc)
 
         # default to None
         examples_dir = None


### PR DESCRIPTION
- method _readfp_ is removed from module _configparser.ConfigParser_ in Python 3.12 which leads to an error if using a user configuration file.
- see https://docs.python.org/3.12/whatsnew/3.12.html#configparser for further information.
- Closes #106 