### PR TITLE
Update touch.md to fix mistake in example command timestamp

### DIFF
--- a/eg/examples/touch.md
+++ b/eg/examples/touch.md
@@ -12,7 +12,7 @@ update the modified and access time of a file to the current instant
 
 update the modified and access time of the file to August 5 at 13:00
 
-    touch -t 08051200 file.txt
+    touch -t 08051300 file.txt
 
 
 update only the modified time to the current instant


### PR DESCRIPTION
Fix mistake in example timestamp argument for touch -t
Description says August 5 at 13:00 but the example command has 08051200
I think fixing the command instead of description is better to avoid any possible confusion that might arise with AM/PM if 12:00 is used.