### PR TITLE
adb: add command to trim/clear all caches

### DIFF
--- a/eg/examples/adb.md
+++ b/eg/examples/adb.md
@@ -266,6 +266,11 @@ Print the complete `pm` help by passing no arguments:
 
     adb shell pm
 
+Clear the caches of all apps. This command requires a size of cache to be
+cleared. So instead of calculating it manually, simply pass it a max value,
+like the overall storage size:
+
+    adb shell pm trim-caches 256 GB
 
 
 ## Pull an apk Off a Device


### PR DESCRIPTION
Clearing all caches can be useful to get rid of e.g. broken files in cache where one does not know what app might be the culprit (if e.g. the device suddenly "behaves strangely" and it's not clear what causes it). So it would be good to have this command handy.